### PR TITLE
Add missing pulseaudio, secrets API and notification permissions

### DIFF
--- a/org.kde.tokodon.json
+++ b/org.kde.tokodon.json
@@ -8,9 +8,12 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
+        "--socket=pulseaudio",
         "--device=dri",
         "--share=network",
-        "--talk-name=org.kde.kwalletd5"
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.kde.kwalletd5",
+        "--talk-name=org.freedesktop.secrets"
     ],
     "modules": [
         {


### PR DESCRIPTION
This should allow audio to work, non-KDE desktops to authenticate and Tokodon to push notifications now.