### PR TITLE
Enable -Dcrypto=disabled on libsecret

### DIFF
--- a/org.kde.tokodon.json
+++ b/org.kde.tokodon.json
@@ -200,7 +200,8 @@
                 "-Dgtk_doc=false",
                 "-Dintrospection=false",
                 "-Dmanpage=false",
-                "-Dvapi=false"
+                "-Dvapi=false",
+                "-Dcrypto=disabled"
             ]
         },
         {


### PR DESCRIPTION
This fixes problems with libsecret hanging instead of using the dbus protocol to save and retrieve passwords.