### PR TITLE
Don't nuke the logging categories

### DIFF
--- a/org.kde.tokodon.json
+++ b/org.kde.tokodon.json
@@ -26,8 +26,7 @@
         "/lib/cmake",
         "/lib/pkgconfig",
         "/mkspecs",
-        "/share/doc",
-        "/share/qlogging-categories6"
+        "/share/doc"
     ],
     "cleanup-commands": [
         "/app/cleanup-BaseApp.sh"


### PR DESCRIPTION
These are needed if we want KDebugSettings to read them in the future, and they're super small.